### PR TITLE
ci: move workflows to Node 24 actions

### DIFF
--- a/.github/workflows/soliplex.yaml
+++ b/.github/workflows/soliplex.yaml
@@ -72,9 +72,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Run dependency audit


### PR DESCRIPTION
Bump JavaScript actions still on the deprecated Node 20 runtime to their Node 24-native versions after the 2026-06-26 cutover:

- actions/checkout@v4 -> @v6
- astral-sh/setup-uv@v6 -> @v7

Closes #111.